### PR TITLE
added 'black' as default stop-color

### DIFF
--- a/lib/src/svg_parser.dart
+++ b/lib/src/svg_parser.dart
@@ -422,7 +422,10 @@ abstract class SvgParser extends GenericParser {
     if (g == null) {
       throw ParseError('<stop> outside of gradient');
     }
-    final SvgColor color = getSvgColor(attrs.remove('stop-color')?.trim());
+
+    //default stop-color is 'black'. Ref https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stop-color
+    final SvgColor color =
+        getSvgColor(attrs.remove('stop-color')?.trim() ?? 'black');
     if (color != SvgColor.inherit &&
         color != SvgColor.currentColor &&
         !(color is SvgValueColor)) {


### PR DESCRIPTION
Adds 'black' as default stop-color. 

BTW: This looks like a great project! :)

The first file I tried it on resulted in an error, 

```
***** Error in myFilename.svg : skipping *****
     Bad state: Internal error: color inheritance
```     
Fixed by this pr.

Another way to implement it would of course be to accept an empty color here and instead put the default in when loading the si-file, saving some space in the si file, but that would mean slightly more complex loading of the si-file and is a much more heavy modification than this tiny change.