### PR TITLE
Text tags use utf8 to decode

### DIFF
--- a/lib/src/exported.dart
+++ b/lib/src/exported.dart
@@ -392,8 +392,8 @@ abstract class ScalableImage {
       void Function(String)? warnF,
       Color? currentColor}) async {
     final warnArg = warnF ?? (warn ? defaultWarn : nullWarn);
-    final String content =
-        url.data?.contentAsString(encoding: utf8) ?? await http.read(url);
+    final String content = url.data?.contentAsString(encoding: utf8) ??
+        utf8.decode((await http.read(url)).codeUnits);
     return fromSvgString(content,
         compact: compact,
         bigFloats: bigFloats,
@@ -534,8 +534,8 @@ abstract class ScalableImage {
     void Function(String)? warnF,
   }) async {
     final warnArg = warnF ?? (warn ? defaultWarn : nullWarn);
-    final String content =
-        url.data?.contentAsString(encoding: utf8) ?? await http.read(url);
+    final String content = url.data?.contentAsString(encoding: utf8) ??
+        utf8.decode((await http.read(url)).codeUnits);
     return fromAvdString(content,
         compact: compact, bigFloats: bigFloats, warnF: warnArg);
   }

--- a/lib/src/svg_parser.dart
+++ b/lib/src/svg_parser.dart
@@ -46,7 +46,6 @@ library jovial_svg.svg_parser;
 
 import 'dart:async';
 import 'dart:collection';
-import 'dart:convert';
 import 'dart:math';
 import 'dart:typed_data';
 
@@ -177,9 +176,8 @@ abstract class SvgParser extends GenericParser {
   }
 
   void _textEvent(XmlTextEvent e) {
-    final text = utf8.decode(e.text.codeUnits);
-    _currentText?.appendText(text);
-    _currentStyle?.write(text);
+    _currentText?.appendText(e.text);
+    _currentStyle?.write(e.text);
   }
 
   void _endTag(XmlEndElementEvent evt) {

--- a/lib/src/svg_parser.dart
+++ b/lib/src/svg_parser.dart
@@ -46,6 +46,7 @@ library jovial_svg.svg_parser;
 
 import 'dart:async';
 import 'dart:collection';
+import 'dart:convert';
 import 'dart:math';
 import 'dart:typed_data';
 
@@ -176,8 +177,9 @@ abstract class SvgParser extends GenericParser {
   }
 
   void _textEvent(XmlTextEvent e) {
-    _currentText?.appendText(e.text);
-    _currentStyle?.write(e.text);
+    final text = utf8.decode(e.text.codeUnits);
+    _currentText?.appendText(text);
+    _currentStyle?.write(text);
   }
 
   void _endTag(XmlEndElementEvent evt) {


### PR DESCRIPTION
Using utf8 encoding, emoji cannot be displayed normally in Flutter because the string in dart is utf16 encoding.
Test svg: https://openseauserdata.com/files/0817d1e5f53e504601a85e900cae85d1.svg