### PR TITLE
em size conversion.

### DIFF
--- a/lib/src/common_noui.dart
+++ b/lib/src/common_noui.dart
@@ -917,7 +917,12 @@ class BnfLexer {
       return null;
     } else {
       _pos = m.end;
-      return source.substring(m.start, m.end);
+      final value = source.substring(m.start, m.end);
+      if (matcher == _floatMatch &&
+          source.substring(m.end).trim().startsWith('em')) {
+        return (double.parse(value) * 16).toString();
+      }
+      return value;
     }
   }
 


### PR DESCRIPTION
Originally only numbers were taken, but some svgs will use em as the unit of size. 
We can do convert : 1em = 16px
Test svg: https://openseauserdata.com/files/c96e87345e518fa2efb8f710ec10b736.svg