### PR TITLE
fix: Bug in creating temporary directory

### DIFF
--- a/test/test_main.dart
+++ b/test/test_main.dart
@@ -417,7 +417,7 @@ class CanvasRecorder implements Canvas {
   }
 }
 
-void _createSI() {
+void _createSI(Directory tmp) {
   List<String> listFiles(String type, String extension) {
     final List<String> r = [];
     for (final f in Directory('demo/assets/$type').listSync()) {
@@ -429,15 +429,10 @@ void _createSI() {
     return r;
   }
 
-  Directory tmp = Directory.systemTemp.createTempSync();
-  try {
-    final svgFiles = listFiles('svg', 'svg');
-    svg_to_si.SvgToSI().main(['-q', '-o', tmp.absolute.path, ...svgFiles]);
-    final avdFiles = listFiles('avd', 'xml');
-    avd_to_si.AvdToSI().main(['-q', '-o', tmp.absolute.path, ...avdFiles]);
-  } finally {
-    tmp.deleteSync(recursive: true);
-  }
+  final svgFiles = listFiles('svg', 'svg');
+  svg_to_si.SvgToSI().main(['-q', '-o', tmp.absolute.path, ...svgFiles]);
+  final avdFiles = listFiles('avd', 'xml');
+  avd_to_si.AvdToSI().main(['-q', '-o', tmp.absolute.path, ...avdFiles]);
 }
 
 class TestSource extends ScalableImageSource {
@@ -843,6 +838,10 @@ void main() {
     }
   });
   test('cache test', _cacheTest);
-  test('create SI smoke test', _createSI);
+
+  Directory tmp = Directory.systemTemp.createTempSync();
+  test('create SI smoke test', () => _createSI(tmp));
+  tmp.deleteSync(recursive: true);
+
   testSIWidget();
 }


### PR DESCRIPTION
On Windows, `test('create SI smoke test', _createSI);` failed due to following error
```
  PathNotFoundException: Creation of temporary directory failed, path = '/tmp\' (OS Error: The system cannot find the path specified.
  , errno = 3)
  dart:io                     _Directory.createTempSync
  test\test_main.dart 432:37  _createSI
```

And

```
  PathAccessException: Deletion failed, path = 'C:\Users\...\AppData\Local\Temp\a7e5e9bc' (OS Error: The process cannot access the file because it is being used by another process.
  , errno = 32)
  dart:io                    FileSystemEntity.deleteSync
  test\test_main.dart 439:9  _createSI
```
This PR try to fix it.