### PR TITLE
Add ink version of widgets

### DIFF
--- a/example/lib/ink.dart
+++ b/example/lib/ink.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:jovial_svg/jovial_svg.dart';
+
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  final tigerSvg =
+      await ScalableImage.fromSvgAsset(rootBundle, 'assets/tiger.svg');
+  runApp(InkSample(tigerSvg));
+}
+
+class InkSample extends StatelessWidget {
+  final ScalableImage tigerSvg;
+
+  const InkSample(this.tigerSvg, {super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'SVG Ink Sample',
+      home: Material(
+        color: Colors.pink,
+        child: InkWell(
+          onTap: () {},
+          splashColor: Colors.lightBlue.withValues(alpha: 0.4),
+          child: Center(
+            child: SizedBox.square(
+              dimension: 300,
+              child: ScalableImageInk(si: tigerSvg),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/jovial_svg.dart
+++ b/lib/jovial_svg.dart
@@ -62,12 +62,12 @@ POSSIBILITY OF SUCH DAMAGE.
 ///
 library;
 
+export 'src/cache.dart' show ScalableImageCache, ExportedIDLookup;
 export 'src/exported.dart'
     show ScalableImage, ExportedID, ImageDisposeBugWorkaround;
+export 'src/ink.dart' show ScalableImageInk;
 export 'src/widget.dart'
     show
         ScalableImageWidget,
         ScalableImageSource,
-        ScalableImageCache,
-        ScalingTransform,
-        ExportedIDLookup;
+        ScalingTransform;

--- a/lib/src/cache.dart
+++ b/lib/src/cache.dart
@@ -1,0 +1,380 @@
+/*
+MIT License
+
+Copyright (c) 2021-2025, William Foote
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+
+///
+/// Internal widget library - exported with jovial_svg
+///
+library;
+
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:meta/meta.dart';
+
+import 'exported.dart';
+import 'widget.dart';
+
+
+///
+/// A default cache.  By default, this cache holds zero unreferenced
+/// image sources.
+///
+/// This isn't exposed.  On balance, the extremely slight chance of slightly
+/// more convenient instance-sharing isn't worth the slight chance that
+/// someone might think it's OK to change the size to something bigger
+/// than zero, and thereby potentially cause other modules to consume
+/// memory with large, retained assets.
+///
+@internal
+final defaultCache = ScalableImageCache(size: 0);
+
+///
+/// An LRU cache of [ScalableImage] futures derived from [ScalableImageSource]
+/// instances.  A cache with a non-zero size could make
+/// sense, for example,  as part of the state of a
+/// stateful widget that builds entries on demand, and that uses
+/// [ScalableImageWidget.fromSISource] to asynchronously load scalable images.
+/// See, for example, `cache.dart` in the `example` directory.
+///
+/// For a discussion of caching and potential reloading, see
+/// https://github.com/zathras/jovial_svg/issues/10.
+///
+/// If different caching semantics are desired, user code can implement
+/// [ScalableImageCache]; [ScalableImageWidget] does not use any of its
+/// private members.  See also the `demo_hive` application to see how
+/// [ScalableImageSource] can be extended to load from a persistent cache.
+///
+/// Sample usage (see `example/lib/cache.dart` for the full program):
+///
+/// ```
+/// class _HomePageState extends State<HomePage> {
+///  ScalableImageCache _svgCache = ScalableImageCache(size: 70);
+///  ...
+///  @override
+///  Widget build(BuildContext context) {
+///    return ...
+///              ScalableImageWidget.fromSISource(
+///                  cache: _svgCache,
+///                  scale: 1000,
+///                  si: ScalableImageSource.fromSvgHttpUrl(widget.svgs[index]),
+///                  ...),
+///     ...;
+///   }
+/// }
+/// ```
+///
+class ScalableImageCache {
+  final _canonicalized = <ScalableImageSource, _CacheEntry>{};
+
+  int _size;
+
+  // List of unreferenced ScalableImageSource instances, stored as a
+  // doubly-linked list with a dummy head node.  The most recently
+  // used is _lruList._lessRecent, and the least recently used is
+  // _lruList._moreRecent.
+  final _lruList = _CacheEntry._null();
+
+  ///
+  /// Create an image cache that holds up to [size] image sources.
+  /// A [ScalableImageCache] will always keep referenced [ScalableImageSource]
+  /// instances, even if this exceeds the cache size.  In this case, no
+  /// unreferenced images would be kept.
+  ///
+  ScalableImageCache({int size = 0}) : _size = size {
+    _lruList._lessRecent = _lruList;
+    _lruList._moreRecent = _lruList;
+  }
+
+  ///
+  /// The size of the cache.  If the cache holds unreferenced images, the total
+  /// number of images will be held to this size.
+  ///
+  int get size => _size;
+  set size(int val) {
+    if (val < 0) {
+      throw ArgumentError.value(val, 'cache size');
+    }
+    _size = size;
+    _trimLRU();
+  }
+
+  ///
+  /// Called when a [ScalableImageSource] is referenced,
+  /// e.g. in a stateful widget's [State] object's `initState` method.
+  /// Returns a Future for the scalable image.
+  ///
+  /// Application code where cache is present should use the returned
+  /// future, and not use [ScalableImageSource.createSI] directly.
+  ///
+  /// This method calls [addReferenceV2].
+  ///
+  /// [src]  The source of the scalable image
+  /// [ifAvailableSync]  An optional function that is called synchronously if
+  /// the `ScalableImage` is available in the cache.  (Added in version
+  /// 1.1.12)
+  @Deprecated('Use addReferenceV2 instead')
+  Future<ScalableImage> addReference(ScalableImageSource src,
+      {ScalableImage Function(ScalableImage)? ifAvailableSync}) {
+    final result = addReferenceV2(src);
+    if (result is Future<ScalableImage>) {
+      return result;
+    } else {
+      if (ifAvailableSync != null) {
+        ifAvailableSync(result);
+      }
+      return Future.value(result);
+    }
+  }
+
+  ///
+  /// Called when a [ScalableImageSource] is referenced,
+  /// e.g. in a stateful widget's [State] object's `initState` method.
+  /// Returns a Future for the scalable image.
+  ///
+  /// Application code where a cache is present should use the returned
+  /// value, and not use [ScalableImageSource.createSI] directly.
+  ///
+  /// [src]  The source of the scalable image
+  FutureOr<ScalableImage> addReferenceV2(ScalableImageSource src) {
+    _CacheEntry? e = _canonicalized[src];
+    if (e == null) {
+      e = _CacheEntry(src, src.createSI());
+      final k = src.asKey;
+      assert(k == src);
+      _canonicalized[k] = e;
+    } else {
+      _verifyCorrectHash(src, e._siSrc!);
+      if (e._lessRecent != null) {
+        // Now it's referenced, so we take it off the LRU list.
+        assert(e._refCount == 0);
+        e._lessRecent!._moreRecent = e._moreRecent;
+        e._moreRecent!._lessRecent = e._lessRecent;
+        e._lessRecent = e._moreRecent = null;
+      } else {
+        assert(e._refCount > 0);
+      }
+    }
+    e._refCount++;
+    return e._si!;
+  }
+
+  void _verifyCorrectHash(ScalableImageSource key, ScalableImageSource found) {
+    if (key != found) {
+      // Very unexpected; I think this would be a bug in Map.
+      throw ArgumentError('Found key $found that is != search: $key');
+    }
+    if (key.hashCode != found.hashCode) {
+      throw ArgumentError('Key $key hash ${key.hashCode} is == existing key '
+          '$found, hash ${found.hashCode}');
+    }
+  }
+
+  ///
+  /// Called when a source is dereferenced, e.g. by a stateful widget's
+  /// [State] object being disposed.  Throws an exception if there had been
+  /// no matching call to [addReferenceV2] for this source.
+  ///
+  void removeReference(ScalableImageSource src) {
+    _CacheEntry? e = _canonicalized[src];
+    if (e == null) {
+      throw ArgumentError.value(src, 'Not in cache', 'src');
+    } else if (e._refCount <= 0) {
+      throw ArgumentError.value(src, 'Extra attempt to removeReference', 'src');
+    }
+    assert(e._lessRecent == null);
+    assert(e._moreRecent == null);
+    e._refCount--;
+    if (e._refCount == 0) {
+      _addToLRU(e);
+    }
+  }
+
+  ///
+  /// If the image referenced by src is in the cache, force it to be
+  /// reloaded the next time it is used.
+  ///
+  void forceReload(ScalableImageSource src) {
+    final _CacheEntry? old = _canonicalized.remove(src);
+    if (old == null) {
+      return;
+    }
+    final e = _CacheEntry(src, src.createSI());
+    final k = src.asKey;
+    assert(k == src);
+    _canonicalized[k] = e;
+    if (old._refCount > 0) {
+      e._refCount = old._refCount;
+      assert(old._lessRecent == null && old._moreRecent == null);
+    } else {
+      e._lessRecent = old._lessRecent;
+      e._moreRecent = old._moreRecent;
+      assert(e._lessRecent!._moreRecent == old);
+      e._lessRecent!._moreRecent = e;
+      assert(e._moreRecent!._lessRecent == old);
+      e._moreRecent!._lessRecent = e;
+    }
+  }
+
+  void _addToLRU(_CacheEntry e) {
+    assert(e._moreRecent == null);
+    if (_size > 0) {
+      // e is now the most recent.  _lruList.lessRecent points to the
+      // most recent, and _lruList.moreRecent points to the least recent.
+      // Remember, the list wraps around at the dummy head node.
+      e._moreRecent = _lruList;
+      e._lessRecent = _lruList._lessRecent;
+      _lruList._lessRecent!._moreRecent = e;
+      _lruList._lessRecent = e;
+
+      _trimLRU();
+    } else {
+      _removeFromCanonicalized(e);
+    }
+  }
+
+  void _trimLRU() {
+    while (_lruList._lessRecent != _lruList && _canonicalized.length > _size) {
+      // While lruList isn't empty, and we're over our capacity
+      final victim = _lruList._moreRecent!; // That's the least recently used
+      assert(victim != _lruList);
+      _removeFromCanonicalized(victim);
+      victim._moreRecent!._lessRecent = victim._lessRecent;
+      victim._lessRecent!._moreRecent = victim._moreRecent;
+    }
+  }
+
+  void _removeFromCanonicalized(_CacheEntry victim) {
+    final _CacheEntry? removed = _canonicalized.remove(victim._siSrc);
+    assert(identical(removed, victim));
+    assert(victim._refCount == 0);
+  }
+}
+
+// An entry in the cache, which might be held on the LRU list.  The LRU list
+// is doubly-linked and wraps around to a dummy head node.
+//
+// Flutter's LinkedListEntry<T> didn't quite fit, and it's not like a
+// doubly-linked list is hard, anyway.
+class _CacheEntry {
+  final ScalableImageSource? _siSrc;
+  FutureOr<ScalableImage>? _si;
+  int _refCount = 0;
+  _CacheEntry? _moreRecent;
+  _CacheEntry? _lessRecent;
+  // Invariant:  If refCount is 0, _moreRecent and _lessRecent are non-null
+  // Invariant:  If _moreRecent is null, refCount > 0
+  // Invariant:  If _lessRecent is null, refCount > 0
+
+  _CacheEntry(ScalableImageSource this._siSrc, Future<ScalableImage> this._si) {
+    unawaited(_replaceFuture());
+  }
+
+  _CacheEntry._null()
+      : _siSrc = null,
+        _si = null;
+
+  Future<void> _replaceFuture() async {
+    try {
+      _si = await _si!;
+    } catch (e) {
+      // Ignore -- leave the Future instance in the cache; it has the
+      // error, ready and waiting for anyone who awaits.
+    }
+  }
+}
+
+///
+/// Used to look up what part of a [ScalableImage] is
+/// clicked on within a [ScalableImageWidget].
+///
+/// An SVG node can have a name in its `id` attribute.  When an SVG is read,
+/// or converted to an SI, these ID values can be marked as exported.  This can
+/// be done by listing the IDs, or by using a regular expression.  For example,
+/// to build an SI where all ID values are exported, you can specify
+/// `-x '.*'` to `svg_to_si`.  Each exported ID does add some overhead, so
+/// in production, it's best to only export the ones you need.
+///
+/// A [ScalableImageWidget] can have an [ExportedIDLookup] instance associated
+/// with it.  This can be used, for example, to determine which node(s) are
+/// under a mouse click (or other tap event).
+///
+/// Usage:
+/// ```
+/// class _GlorpState extends State<GlorpWidget> {
+///     final ExportedIDLookup _idLookup = ExportedIDLookup();
+///     ...
+///     @override
+///     Widget build() => ...
+///         GestureDetector(
+///           onTapDown: _handleTapDown,
+///           child: ScalableImageWidget(
+///             ...
+///             lookup: _idLookup))
+///       ...;
+///
+///   void _handleTapDown(TapDownDetails event) {
+///     final Set<String> hits = _idLookup.hits(event.localPosition);
+///     print('Tap down at ${event.localPosition}:  $hits');
+///   }
+/// }
+/// ```
+///
+/// See `example/lib/animation.dart` and `demo/lib/main.dart` for
+/// more complete examples.
+///
+class ExportedIDLookup {
+  @internal
+  ScalableImage? si;
+  @internal
+  ScalingTransform? lastTransform;
+
+  ///
+  /// Get the exported IDs from the underlying [ScalableImage] instance, if
+  /// it has been loaded.  The [ExportedID]s will be in the coordinate system
+  /// of the [ScalableImage].  See also [scalingTransform].
+  ///
+  Set<ExportedID> get exportedIDs => si?.exportedIDs ?? const {};
+
+  ///
+  /// Get the [ScalingTransform] needed to convert coordinates between the
+  /// coordinate system of the [ScalableImage]'s [exportedIDs] and the
+  /// containing [ScalableImageWidget].
+  ///
+  ScalingTransform get scalingTransform =>
+      lastTransform ?? ScalingTransform.identity;
+
+  ///
+  /// Return the set of node IDs whose bounding rectangles contain [p].
+  ///
+  Set<String> hits(Offset p) {
+    final Set<String> result = {};
+    p = scalingTransform.toSICoordinate(p);
+    for (final e in exportedIDs) {
+      if (e.boundingRect.contains(p)) {
+        result.add(e.id);
+      }
+    }
+    return result;
+  }
+}

--- a/lib/src/ink.dart
+++ b/lib/src/ink.dart
@@ -1,0 +1,426 @@
+library;
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import 'cache.dart';
+import 'exported.dart';
+import 'widget.dart';
+
+///
+/// A widget for displaying a [ScalableImage] on in an [Ink].  This can
+/// be used to display an SVG on top of a [Material] while allowing
+/// other layers to be drawn.  An example of this is a [MaterialButton]'s
+/// splash effect.
+///
+/// The image can be automatically scaled by the widget, and fit into the
+/// available area with a `BoxFit` and an `Alignment`.  Where loading is
+/// required, a [ScalableImageCache] can be provided.
+///
+/// Note that rendering a scalable image can be time-consuming if the
+/// underlying scene is complex.  Notably, GPU performance can be a
+/// bottleneck.  If animations are played over an unchanging [ScalableImage],
+/// wrapping the [ScalableImageInk] in Flutter's `RepaintBoundary`
+/// might result in significantly better performance.
+///
+abstract class ScalableImageInk extends StatefulWidget {
+  ///
+  /// Whether the underlying `ScalableImage`'s painting is complex enough
+  /// to benefit from caching.  This is forwarded to [CustomPaint] -- see
+  /// [CustomPaint.isComplex].
+  ///
+  final bool isComplex;
+
+  final ExportedIDLookup? _lookup;
+
+  const ScalableImageInk._p(Key? key, this.isComplex, this._lookup)
+      : super(key: key);
+
+  ///
+  /// Create a widget to display a pre-loaded [ScalableImage].
+  /// This is the preferred constructor, because the widget can display the
+  /// SI immediately.  It does, however, place responsibility for any
+  /// asynchronous loading on the caller.
+  ///
+  /// If the [ScalableImage] contains embedded images, it is recommended
+  /// that the caller await a call to [ScalableImage.prepareImages()] before
+  /// creating the widget.  See also [ScalableImage.unprepareImages()].  If
+  /// this is not done, there might be a delay after the widget is created
+  /// while the image(s) are decoded.
+  ///
+  /// [fit] controls how the scalable image is scaled within the widget.
+  ///
+  /// [alignment] sets the alignment of the scalable image within the widget.
+  ///
+  /// [clip], if true, will cause the widget to enforce the boundaries of
+  /// the scalable image.
+  ///
+  /// [background], if provided, will be the background color for a layer under
+  /// the SVG asset.  In relatively rare circumstances, this can be needed.
+  /// For example, browsers generally render an SVG over a white background,
+  /// which affects advanced use of the `mix-blend-mode` attribute applied over
+  /// areas without other drawing.
+  ///
+  /// [isComplex] see [ScalableImageInk.isComplex]
+  ///
+  /// [lookup] is used to look up node IDs that were exported in an SVG
+  /// asset.  See [ExportedIDLookup].
+  ///
+  factory ScalableImageInk(
+          {Key? key,
+          required ScalableImage si,
+          BoxFit fit = BoxFit.contain,
+          Alignment alignment = Alignment.center,
+          bool clip = true,
+          Color? background,
+          bool isComplex = false,
+          ExportedIDLookup? lookup}) =>
+      _SyncSIInk(
+          key, si, fit, alignment, clip, background, isComplex, lookup);
+
+  ///
+  /// Create a widget to load and then render a [ScalableImage].  In a
+  /// production application, pre-loading the [ScalableImage] and using
+  /// the default constructor is usually preferable, because the
+  /// asynchronous loading that is necessary with an asynchronous
+  /// source might cause a momentary flash.  If the widget is frequently
+  /// rebuilt, it is generally recommended to provide a [cache] with an
+  /// appropriate lifetime and size.
+  ///
+  /// For a discussion of caching and potential reloading, see
+  /// https://github.com/zathras/jovial_svg/issues/10.
+  ///
+  /// [fit] controls how the scalable image is scaled within the widget.
+  ///
+  /// [alignment] sets the alignment of the scalable image within the widget.
+  ///
+  /// [clip], if true, will cause the widget to enforce the boundaries of
+  /// the scalable image.
+  ///
+  /// [cache] can used to share [ScalableImage] instances, and avoid excessive
+  /// reloading.  If null, a default cache that retains no unreferenced
+  /// images is used.
+  ///
+  /// [reload] forces the [ScalableImage] to be reloaded, e.g. if a networking
+  /// error might have been resolved, or if the asset might have changed.
+  ///
+  /// [isComplex] see [ScalableImageWidget.isComplex]
+  ///
+  /// [lookup] is used to look up node IDs that were exported in an SVG
+  /// asset.  See [ExportedIDLookup].
+  ///
+  /// [onLoading] is called to give a widget to show while the asset is being
+  /// loaded.  It defaults to a 1x1 SizedBox.
+  ///
+  /// [onError] is called to give a widget to show if the asset has failed
+  /// loading.  It defaults to onLoading.
+  ///
+  /// [switcher], if set, is called when switching to a new widget (either from
+  /// nothing to onLoading, or onLoading to either loaded or onError).  A
+  /// reasonable choice is to create an `AnimatedSwitcher`.  See, for example,
+  /// `example/lib/cache.dart`.
+  ///
+  /// [currentColor], if provided, sets the [ScalableImage.currentColor] of
+  /// the displayed image, using [ScalableImage.modifyCurrentColor] to create
+  /// an appropriate [ScalableImage] instance.
+  ///
+  /// [background], if provided, will be the background color for a layer under
+  /// the SVG asset.  In relatively rare circumstances, this can be needed.
+  /// For example, browsers generally render an SVG over a white background,
+  /// which affects advanced use of the `mix-blend-mode` attribute applied over
+  /// areas without other drawing.
+  ///
+  /// NOTE:  If no cache is provided, a default of size zero is used.
+  /// There is no provision for client code to change the size of this default
+  /// cache; this is intentional.  Having a system-wide cache would invite
+  /// conflicts in the case where two unrelated modules within a single
+  /// application attempted to set a cache size.  This could even result in
+  /// a too-large cache retaining large SVG assets, perhaps leading to
+  /// memory exhaustion.  Any module or application that wishes
+  /// to have a global cache can simply hold one in a static data member,
+  /// and provide it as the cache parameter to the widgets it manages.
+  ///
+  factory ScalableImageInk.fromSISource({
+    Key? key,
+    required ScalableImageSource si,
+    BoxFit fit = BoxFit.contain,
+    Alignment alignment = Alignment.center,
+    bool clip = true,
+    Color? currentColor,
+    Color? background,
+    bool reload = false,
+    bool isComplex = false,
+    ExportedIDLookup? lookup,
+    ScalableImageCache? cache,
+    Widget Function(BuildContext)? onLoading,
+    Widget Function(BuildContext)? onError,
+    Widget Function(BuildContext, Widget child)? switcher
+  }) {
+    onLoading ??= _AsyncSIInk.defaultOnLoading;
+    onError ??= onLoading;
+    cache = cache ?? defaultCache;
+    if (reload) {
+      cache.forceReload(si);
+    }
+    return _AsyncSIInk(
+        key,
+        si,
+        fit,
+        alignment,
+        clip,
+        cache,
+        onLoading,
+        onError,
+        switcher,
+        currentColor,
+        background,
+        isComplex,
+        lookup);
+  }
+}
+
+class _AsyncSIInk extends ScalableImageInk {
+  final ScalableImageSource _siSource;
+  final ScalableImageCache _cache;
+  final BoxFit _fit;
+  final Alignment _alignment;
+  final bool _clip;
+  // final double _scale;
+  final Color? _currentColor;
+  final Color? _background;
+
+  final Widget Function(BuildContext) _onLoading;
+  final Widget Function(BuildContext) _onError;
+  final Widget Function(BuildContext, Widget child)? _switcher;
+
+  const _AsyncSIInk(
+      Key? key,
+      this._siSource,
+      this._fit,
+      this._alignment,
+      this._clip,
+      // this._scale,
+      this._cache,
+      this._onLoading,
+      this._onError,
+      this._switcher,
+      this._currentColor,
+      this._background,
+      bool isComplex,
+      ExportedIDLookup? lookup)
+      : super._p(key, isComplex, lookup);
+
+  @override
+  State<StatefulWidget> createState() => _AsyncSIInkState();
+
+  static Widget defaultOnLoading(BuildContext c) =>
+      const SizedBox(width: 1, height: 1);
+}
+
+class _AsyncSIInkState extends State<_AsyncSIInk> {
+  static final ScalableImage _error = ScalableImage.blank();
+  ScalableImage? _si;
+
+  @override
+  void initState() {
+    super.initState();
+    final si = widget._cache.addReferenceV2(widget._siSource);
+    if (si is ScalableImage) {
+      _si = si;
+    } else {
+      _registerWithFuture(widget._siSource, si);
+    }
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    widget._cache.removeReference(widget._siSource);
+  }
+
+  @override
+  void didUpdateWidget(covariant _AsyncSIInk old) {
+    super.didUpdateWidget(old);
+    if (old._siSource != widget._siSource || old._cache != widget._cache) {
+      final si = widget._cache.addReferenceV2(widget._siSource);
+      old._cache.removeReference(old._siSource);
+      if (si is ScalableImage) {
+        _si = si;
+      } else {
+        _si = null;
+        _registerWithFuture(widget._siSource, si);
+      }
+    }
+  }
+
+  void _registerWithFuture(ScalableImageSource src, Future<ScalableImage> si) {
+    unawaited(si.then((ScalableImage a) {
+      if (mounted && widget._siSource == src) {
+        // If it's not stale, perhaps due to reparenting
+        setState(() => _si = a);
+      }
+    }, onError: (Object err) {
+      widget._siSource.warnArg('Error loading:  $err');
+      if (mounted && widget._siSource == src) {
+        setState(() => _si = _error);
+      }
+    }));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    var si = _si;
+    final Widget result;
+    final lookup = widget._lookup;
+    if (lookup != null) {
+      lookup.si = si; // Null it out if the SI isn't loaded yet
+    }
+    if (si == null) {
+      result = widget._onLoading(context);
+    } else if (identical(si, _error)) {
+      result = widget._onError(context);
+    } else {
+      final cc = widget._currentColor;
+      if (cc != null) {
+        si = si.modifyCurrentColor(cc);
+        // Very cheap, just one instance creation
+      }
+      result = _SyncSIInk(null, si, widget._fit, widget._alignment, widget._clip, widget._background, widget.isComplex, widget._lookup);
+    }
+    final switcher = widget._switcher;
+    if (switcher == null) {
+      return result;
+    } else {
+      return switcher(context, result);
+    }
+  }
+}
+
+class _SyncSIInk extends ScalableImageInk {
+  final ScalableImage _si;
+  final BoxFit _fit;
+  final Alignment _alignment;
+  final bool _clip;
+  final Color? _background;
+
+  const _SyncSIInk(
+    Key? key,
+    this._si,
+    this._fit,
+    this._alignment,
+    this._clip,
+    this._background,
+    bool isComplex,
+    ExportedIDLookup? lookup,
+  ) : super._p(key, isComplex, lookup);
+
+  @override
+  State<StatefulWidget> createState() => _SyncSIInkState();
+}
+
+class _SyncSIInkState extends State<_SyncSIInk> {
+  @override
+  Widget build(BuildContext context) {
+    return Ink(
+      decoration: _SIDecoration(widget._si, widget._fit, widget._alignment,
+          widget._clip, widget._background, widget._lookup),
+    );
+  }
+}
+
+// This could theoretically be exposed to be used as a general decoration
+// usable in a Container for example, however a lot of the functionality for
+// this would require additional work and as such has not been attempted.
+class _SIDecoration extends Decoration {
+  final ScalableImage _si;
+  final BoxFit _fit;
+  final Alignment _alignment;
+  final bool _clip;
+  final Color? _background;
+  final ExportedIDLookup? _lookup;
+
+  const _SIDecoration(this._si, this._fit, this._alignment, this._clip,
+      this._background, this._lookup);
+
+  @factory
+  @override
+  BoxPainter createBoxPainter([covariant VoidCallback? onChanged]) {
+    _si.prepareImages().then((v) => onChanged?.call());
+    return _SIBoxPainter(
+      onChanged,
+      _si,
+      _fit,
+      _alignment,
+      _clip,
+      _background,
+      _lookup,
+    );
+  }
+}
+
+class _SIBoxPainter extends BoxPainter {
+  final ScalableImage _si;
+  final BoxFit _fit;
+  final Alignment _alignment;
+  final bool _clip;
+  final Color? _background;
+  final ExportedIDLookup? _lookup;
+
+  const _SIBoxPainter(
+    super.onChanged,
+    this._si,
+    this._fit,
+    this._alignment,
+    this._clip,
+    this._background,
+    this._lookup,
+  );
+
+  @override
+  void dispose() {
+    super.dispose();
+    _si.unprepareImages();
+  }
+
+  @override
+  void paint(Canvas canvas, Offset offset, ImageConfiguration configuration) {
+    assert(configuration.size != null);
+    final size = configuration.size!;
+    final bounds = offset & size;
+    final background = _background;
+    final xform = ScalingTransform(
+      containerSize: size,
+      siViewport: _si.viewport,
+      fit: _fit,
+      alignment: _alignment,
+    );
+    final lookup = _lookup;
+    if (lookup != null) {
+      lookup.lastTransform = xform;
+      lookup.si = _si;
+    }
+
+    canvas.save();
+    try {
+      if (_clip) {
+        canvas.clipRect(bounds);
+      }
+      if (background != null) {
+        canvas.drawColor(background, BlendMode.src);
+        canvas.saveLayer(bounds, Paint());
+        canvas.drawColor(const Color(0x00ffffff), BlendMode.src);
+      }
+      try {
+        canvas.translate(offset.dx, offset.dy);
+        xform.applyToCanvas(canvas);
+        _si.paint(canvas);
+      } finally {}
+    } finally {
+      canvas.restore();
+      if (background != null) {
+        canvas.restore();
+      }
+    }
+  }
+}

--- a/lib/src/widget.dart
+++ b/lib/src/widget.dart
@@ -34,7 +34,9 @@ import 'dart:math' show min, max;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:meta/meta.dart';
 
+import 'cache.dart';
 import 'common_noui.dart';
 import 'exported.dart';
 
@@ -189,7 +191,7 @@ abstract class ScalableImageWidget extends StatefulWidget {
       Widget Function(BuildContext, Widget child)? switcher}) {
     onLoading ??= _AsyncSIWidget.defaultOnLoading;
     onError ??= onLoading;
-    cache = cache ?? ScalableImageCache._defaultCache;
+    cache = cache ?? defaultCache;
     if (reload) {
       cache.forceReload(si);
     }
@@ -324,8 +326,8 @@ class _SIPainter extends CustomPainter {
           alignment: _alignment);
       final lookup = _lookup;
       if (lookup != null) {
-        lookup._lastTransform = xform;
-        lookup._si = _si;
+        lookup.lastTransform = xform;
+        lookup.si = _si;
       }
       canvas.save();
       try {
@@ -432,7 +434,7 @@ class _AsyncSIWidgetState extends State<_AsyncSIWidget> {
         setState(() => _si = a);
       }
     }, onError: (Object err) {
-      widget._siSource._warnArg('Error loading:  $err');
+      widget._siSource.warnArg('Error loading:  $err');
       if (mounted && widget._siSource == src) {
         setState(() => _si = _error);
       }
@@ -445,7 +447,7 @@ class _AsyncSIWidgetState extends State<_AsyncSIWidget> {
     final Widget result;
     final lookup = widget._lookup;
     if (lookup != null) {
-      lookup._si = si; // Null it out if the SI isn't loaded yet
+      lookup.si = si; // Null it out if the SI isn't loaded yet
     }
     if (si == null) {
       result = widget._onLoading(context);
@@ -562,7 +564,8 @@ abstract class ScalableImageSource {
     // I really mean it :-)
   }
 
-  void Function(String) get _warnArg =>
+  @internal
+  void Function(String) get warnArg =>
       warnF ??
       (warn // ignore: deprecated_member_use_from_same_package
           ? defaultWarn
@@ -890,7 +893,7 @@ class _SvgBundleSource extends ScalableImageSource {
       currentColor: currentColor,
       compact: compact,
       bigFloats: bigFloats,
-      warnF: _warnArg,
+      warnF: warnArg,
       exportedIDs: exportedIDs);
 
   @override
@@ -958,7 +961,7 @@ class _SvgHttpSource extends ScalableImageSource {
       currentColor: currentColor,
       compact: compact,
       bigFloats: bigFloats,
-      warnF: _warnArg,
+      warnF: warnArg,
       defaultEncoding: defaultEncoding,
       exportedIDs: exportedIDs,
       httpHeaders: httpHeaders);
@@ -1092,7 +1095,7 @@ class _AvdHttpSource extends ScalableImageSource {
   Future<ScalableImage> createSI() => ScalableImage.fromAvdHttpUrl(url,
       compact: compact,
       bigFloats: bigFloats,
-      warnF: _warnArg,
+      warnF: warnArg,
       defaultEncoding: defaultEncoding,
       httpHeaders: httpHeaders);
 
@@ -1162,273 +1165,6 @@ class _SIBundleSource extends ScalableImageSource {
   String toString() => '_SIBundleSource($key $bundle $currentColor)';
 }
 
-// An entry in the cache, which might be held on the LRU list.  The LRU list
-// is doubly-linked and wraps around to a dummy head node.
-//
-// Flutter's LinkedListEntry<T> didn't quite fit, and it's not like a
-// doubly-linked list is hard, anyway.
-class _CacheEntry {
-  final ScalableImageSource? _siSrc;
-  FutureOr<ScalableImage>? _si;
-  int _refCount = 0;
-  _CacheEntry? _moreRecent;
-  _CacheEntry? _lessRecent;
-  // Invariant:  If refCount is 0, _moreRecent and _lessRecent are non-null
-  // Invariant:  If _moreRecent is null, refCount > 0
-  // Invariant:  If _lessRecent is null, refCount > 0
-
-  _CacheEntry(ScalableImageSource this._siSrc, Future<ScalableImage> this._si) {
-    unawaited(_replaceFuture());
-  }
-
-  _CacheEntry._null()
-      : _siSrc = null,
-        _si = null;
-
-  Future<void> _replaceFuture() async {
-    try {
-      _si = await _si!;
-    } catch (e) {
-      // Ignore -- leave the Future instance in the cache; it has the
-      // error, ready and waiting for anyone who awaits.
-    }
-  }
-}
-
-///
-/// An LRU cache of [ScalableImage] futures derived from [ScalableImageSource]
-/// instances.  A cache with a non-zero size could make
-/// sense, for example,  as part of the state of a
-/// stateful widget that builds entries on demand, and that uses
-/// [ScalableImageWidget.fromSISource] to asynchronously load scalable images.
-/// See, for example, `cache.dart` in the `example` directory.
-///
-/// For a discussion of caching and potential reloading, see
-/// https://github.com/zathras/jovial_svg/issues/10.
-///
-/// If different caching semantics are desired, user code can implement
-/// [ScalableImageCache]; [ScalableImageWidget] does not use any of its
-/// private members.  See also the `demo_hive` application to see how
-/// [ScalableImageSource] can be extended to load from a persistent cache.
-///
-/// Sample usage (see `example/lib/cache.dart` for the full program):
-///
-/// ```
-/// class _HomePageState extends State<HomePage> {
-///  ScalableImageCache _svgCache = ScalableImageCache(size: 70);
-///  ...
-///  @override
-///  Widget build(BuildContext context) {
-///    return ...
-///              ScalableImageWidget.fromSISource(
-///                  cache: _svgCache,
-///                  scale: 1000,
-///                  si: ScalableImageSource.fromSvgHttpUrl(widget.svgs[index]),
-///                  ...),
-///     ...;
-///   }
-/// }
-/// ```
-///
-class ScalableImageCache {
-  final _canonicalized = <ScalableImageSource, _CacheEntry>{};
-
-  int _size;
-
-  // List of unreferenced ScalableImageSource instances, stored as a
-  // doubly-linked list with a dummy head node.  The most recently
-  // used is _lruList._lessRecent, and the least recently used is
-  // _lruList._moreRecent.
-  final _lruList = _CacheEntry._null();
-
-  ///
-  /// Create an image cache that holds up to [size] image sources.
-  /// A [ScalableImageCache] will always keep referenced [ScalableImageSource]
-  /// instances, even if this exceeds the cache size.  In this case, no
-  /// unreferenced images would be kept.
-  ///
-  ScalableImageCache({int size = 0}) : _size = size {
-    _lruList._lessRecent = _lruList;
-    _lruList._moreRecent = _lruList;
-  }
-
-  ///
-  /// A default cache.  By default, this cache holds zero unreferenced
-  /// image sources.
-  ///
-  /// This isn't exposed.  On balance, the extremely slight chance of slightly
-  /// more convenient instance-sharing isn't worth the slight chance that
-  /// someone might think it's OK to change the size to something bigger
-  /// than zero, and thereby potentially cause other modules to consume
-  /// memory with large, retained assets.
-  ///
-  static final _defaultCache = ScalableImageCache(size: 0);
-
-  ///
-  /// The size of the cache.  If the cache holds unreferenced images, the total
-  /// number of images will be held to this size.
-  ///
-  int get size => _size;
-  set size(int val) {
-    if (val < 0) {
-      throw ArgumentError.value(val, 'cache size');
-    }
-    _size = size;
-    _trimLRU();
-  }
-
-  ///
-  /// Called when a [ScalableImageSource] is referenced,
-  /// e.g. in a stateful widget's [State] object's `initState` method.
-  /// Returns a Future for the scalable image.
-  ///
-  /// Application code where cache is present should use the returned
-  /// future, and not use [ScalableImageSource.createSI] directly.
-  ///
-  /// This method calls [addReferenceV2].
-  ///
-  /// [src]  The source of the scalable image
-  /// [ifAvailableSync]  An optional function that is called synchronously if
-  /// the `ScalableImage` is available in the cache.  (Added in version
-  /// 1.1.12)
-  @Deprecated('Use addReferenceV2 instead')
-  Future<ScalableImage> addReference(ScalableImageSource src,
-      {ScalableImage Function(ScalableImage)? ifAvailableSync}) {
-    final result = addReferenceV2(src);
-    if (result is Future<ScalableImage>) {
-      return result;
-    } else {
-      if (ifAvailableSync != null) {
-        ifAvailableSync(result);
-      }
-      return Future.value(result);
-    }
-  }
-
-  ///
-  /// Called when a [ScalableImageSource] is referenced,
-  /// e.g. in a stateful widget's [State] object's `initState` method.
-  /// Returns a Future for the scalable image.
-  ///
-  /// Application code where a cache is present should use the returned
-  /// value, and not use [ScalableImageSource.createSI] directly.
-  ///
-  /// [src]  The source of the scalable image
-  FutureOr<ScalableImage> addReferenceV2(ScalableImageSource src) {
-    _CacheEntry? e = _canonicalized[src];
-    if (e == null) {
-      e = _CacheEntry(src, src.createSI());
-      final k = src.asKey;
-      assert(k == src);
-      _canonicalized[k] = e;
-    } else {
-      _verifyCorrectHash(src, e._siSrc!);
-      if (e._lessRecent != null) {
-        // Now it's referenced, so we take it off the LRU list.
-        assert(e._refCount == 0);
-        e._lessRecent!._moreRecent = e._moreRecent;
-        e._moreRecent!._lessRecent = e._lessRecent;
-        e._lessRecent = e._moreRecent = null;
-      } else {
-        assert(e._refCount > 0);
-      }
-    }
-    e._refCount++;
-    return e._si!;
-  }
-
-  void _verifyCorrectHash(ScalableImageSource key, ScalableImageSource found) {
-    if (key != found) {
-      // Very unexpected; I think this would be a bug in Map.
-      throw ArgumentError('Found key $found that is != search: $key');
-    }
-    if (key.hashCode != found.hashCode) {
-      throw ArgumentError('Key $key hash ${key.hashCode} is == existing key '
-          '$found, hash ${found.hashCode}');
-    }
-  }
-
-  ///
-  /// Called when a source is dereferenced, e.g. by a stateful widget's
-  /// [State] object being disposed.  Throws an exception if there had been
-  /// no matching call to [addReferenceV2] for this source.
-  ///
-  void removeReference(ScalableImageSource src) {
-    _CacheEntry? e = _canonicalized[src];
-    if (e == null) {
-      throw ArgumentError.value(src, 'Not in cache', 'src');
-    } else if (e._refCount <= 0) {
-      throw ArgumentError.value(src, 'Extra attempt to removeReference', 'src');
-    }
-    assert(e._lessRecent == null);
-    assert(e._moreRecent == null);
-    e._refCount--;
-    if (e._refCount == 0) {
-      _addToLRU(e);
-    }
-  }
-
-  ///
-  /// If the image referenced by src is in the cache, force it to be
-  /// reloaded the next time it is used.
-  ///
-  void forceReload(ScalableImageSource src) {
-    final _CacheEntry? old = _canonicalized.remove(src);
-    if (old == null) {
-      return;
-    }
-    final e = _CacheEntry(src, src.createSI());
-    final k = src.asKey;
-    assert(k == src);
-    _canonicalized[k] = e;
-    if (old._refCount > 0) {
-      e._refCount = old._refCount;
-      assert(old._lessRecent == null && old._moreRecent == null);
-    } else {
-      e._lessRecent = old._lessRecent;
-      e._moreRecent = old._moreRecent;
-      assert(e._lessRecent!._moreRecent == old);
-      e._lessRecent!._moreRecent = e;
-      assert(e._moreRecent!._lessRecent == old);
-      e._moreRecent!._lessRecent = e;
-    }
-  }
-
-  void _addToLRU(_CacheEntry e) {
-    assert(e._moreRecent == null);
-    if (_size > 0) {
-      // e is now the most recent.  _lruList.lessRecent points to the
-      // most recent, and _lruList.moreRecent points to the least recent.
-      // Remember, the list wraps around at the dummy head node.
-      e._moreRecent = _lruList;
-      e._lessRecent = _lruList._lessRecent;
-      _lruList._lessRecent!._moreRecent = e;
-      _lruList._lessRecent = e;
-
-      _trimLRU();
-    } else {
-      _removeFromCanonicalized(e);
-    }
-  }
-
-  void _trimLRU() {
-    while (_lruList._lessRecent != _lruList && _canonicalized.length > _size) {
-      // While lruList isn't empty, and we're over our capacity
-      final victim = _lruList._moreRecent!; // That's the least recently used
-      assert(victim != _lruList);
-      _removeFromCanonicalized(victim);
-      victim._moreRecent!._lessRecent = victim._lessRecent;
-      victim._lessRecent!._moreRecent = victim._moreRecent;
-    }
-  }
-
-  void _removeFromCanonicalized(_CacheEntry victim) {
-    final _CacheEntry? removed = _canonicalized.remove(victim._siSrc);
-    assert(identical(removed, victim));
-    assert(victim._refCount == 0);
-  }
-}
-
 ///
 /// A coordinate system transformation to fit a `ScalableImage` into a
 /// given container, for a given [BoxFit] and [Alignment].  This class is
@@ -1470,7 +1206,7 @@ class ScalingTransform {
   const ScalingTransform._p(this.scaleX, this.scaleY, this.translateX,
       this.translateY, this.siViewport);
 
-  static const _identity =
+  static const identity =
       ScalingTransform._p(1, 1, 0, 0, Rect.fromLTRB(0, 0, 1, 1));
 
   ///
@@ -1548,77 +1284,4 @@ class ScalingTransform {
   Offset toContainerCoordinate(final Offset si) => Offset(
       (si.dx - siViewport.left) * scaleX + translateX,
       (si.dy - siViewport.top) * scaleY + translateY);
-}
-
-///
-/// Used to look up what part of a [ScalableImage] is
-/// clicked on within a [ScalableImageWidget].
-///
-/// An SVG node can have a name in its `id` attribute.  When an SVG is read,
-/// or converted to an SI, these ID values can be marked as exported.  This can
-/// be done by listing the IDs, or by using a regular expression.  For example,
-/// to build an SI where all ID values are exported, you can specify
-/// `-x '.*'` to `svg_to_si`.  Each exported ID does add some overhead, so
-/// in production, it's best to only export the ones you need.
-///
-/// A [ScalableImageWidget] can have an [ExportedIDLookup] instance associated
-/// with it.  This can be used, for example, to determine which node(s) are
-/// under a mouse click (or other tap event).
-///
-/// Usage:
-/// ```
-/// class _GlorpState extends State<GlorpWidget> {
-///     final ExportedIDLookup _idLookup = ExportedIDLookup();
-///     ...
-///     @override
-///     Widget build() => ...
-///         GestureDetector(
-///           onTapDown: _handleTapDown,
-///           child: ScalableImageWidget(
-///             ...
-///             lookup: _idLookup))
-///       ...;
-///
-///   void _handleTapDown(TapDownDetails event) {
-///     final Set<String> hits = _idLookup.hits(event.localPosition);
-///     print('Tap down at ${event.localPosition}:  $hits');
-///   }
-/// }
-/// ```
-///
-/// See `example/lib/animation.dart` and `demo/lib/main.dart` for
-/// more complete examples.
-///
-class ExportedIDLookup {
-  ScalableImage? _si;
-  ScalingTransform? _lastTransform;
-
-  ///
-  /// Get the exported IDs from the underlying [ScalableImage] instance, if
-  /// it has been loaded.  The [ExportedID]s will be in the coordinate system
-  /// of the [ScalableImage].  See also [scalingTransform].
-  ///
-  Set<ExportedID> get exportedIDs => _si?.exportedIDs ?? const {};
-
-  ///
-  /// Get the [ScalingTransform] needed to convert coordinates between the
-  /// coordinate system of the [ScalableImage]'s [exportedIDs] and the
-  /// containing [ScalableImageWidget].
-  ///
-  ScalingTransform get scalingTransform =>
-      _lastTransform ?? ScalingTransform._identity;
-
-  ///
-  /// Return the set of node IDs whose bounding rectangles contain [p].
-  ///
-  Set<String> hits(Offset p) {
-    final Set<String> result = {};
-    p = scalingTransform.toSICoordinate(p);
-    for (final e in exportedIDs) {
-      if (e.boundingRect.contains(p)) {
-        result.add(e.id);
-      }
-    }
-    return result;
-  }
 }

--- a/test/test_main.dart
+++ b/test/test_main.dart
@@ -32,6 +32,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:jovial_misc/io_utils.dart';
 import 'package:jovial_svg/dom.dart';
 import 'package:jovial_svg/src/avd_parser.dart';
+import 'package:jovial_svg/src/cache.dart';
 import 'package:jovial_svg/src/common.dart';
 import 'package:jovial_svg/src/common_noui.dart';
 import 'package:jovial_svg/src/compact.dart';


### PR DESCRIPTION
This is relation to #124.

The short version is that this PR adds an alternate to ScalableImageWidget called ScalableImageInk which behaves very similarly except that instead of rendering into a CustomPainter, it renders into the underlying Canvas provided by the nearest Material.

The only significant change from the ScalableImageWidget implementation is that I omitted the `scale` parameter. It seemed more difficult to support that properly with Ink and less necessary.

I haven't yet implemented tests or checked that all the different parameters still work exactly as with the Widget implementation, although since it uses a lot of shared logic it should. @zathras If this has a high chance of being merged in, I can look into implementing those and cleaning anything else up in prep for merging. If you have any recommendations/changes etc let me know and I'll try to get them in when I have time.

Instead of adding to the already quite large widget.dart, I moved a few things around to split it up where it seemed to make sense to me. This necessitated a few private members becoming 'public', but I did mark any such as `@internal`.