### PR TITLE
Fix argument parsing and add simple test for input/output

### DIFF
--- a/jovial_svg_transformer/.gitignore
+++ b/jovial_svg_transformer/.gitignore
@@ -1,3 +1,4 @@
 # https://dart.dev/guides/libraries/private-files
 # Created by `dart pub`
 .dart_tool/
+test/temp.si

--- a/jovial_svg_transformer/lib/jovial_svg_transformer.dart
+++ b/jovial_svg_transformer/lib/jovial_svg_transformer.dart
@@ -33,7 +33,7 @@ class ToSI {
     }
   }
 
-  void _usage(final ArgParser argp) {
+  void _usage(final ArgParser argp) async {
     print('');
     print('dart run jovial_svg_transformer [options]'
         ' --input <name> --output <name>');
@@ -45,6 +45,7 @@ class ToSI {
     print('the files images smaller in memory at runtime.  For most files,');
     print('floats offer more than enough precision.');
     print('');
+    await stdout.flush();
     exit(1);
   }
 
@@ -57,6 +58,7 @@ class ToSI {
     argp.addFlag('big',
         abbr: 'b', help: 'Use 64 bit double-precision floats, instead of 32.');
     argp.addFlag('quiet', abbr: 'q', help: 'Quiet:  Suppress warnings.');
+    argp.addFlag('avd', help: 'Use AVD format instead of SVG.');
 
     argp.addMultiOption('exportx',
         abbr: 'x',
@@ -64,6 +66,11 @@ class ToSI {
         help:
             'Export:  Export the SVG node IDs matched by the given regular expression.  '
             'Multiple values may be specified.');
+
+    argp.addOption('export', help: "Export the specified SVG node id.");
+    argp.addOption('input', help: 'Specify input file.');
+    argp.addOption('output', help: 'Specify output file.');
+
     final ArgResults results;
     final String? inFile;
     final String? outFile;
@@ -83,10 +90,10 @@ class ToSI {
     }
     bool big = results['big'] == true;
     bool warn = results['quiet'] != true;
-    for (final String e in (results['export'] as List<String>)) {
+    for (final String e in (results['export'] as List<String>?) ?? []) {
       _exportedIds.add(e);
     }
-    for (final String ex in (results['exportx'] as List<String>)) {
+    for (final String ex in (results['exportx'] as List<String>?) ?? []) {
       _exportedIds.add(RegExp(ex));
     }
     _parseAVD = results['avd'] == true;
@@ -97,6 +104,7 @@ class ToSI {
     final f = File(inFile);
     if (!f.existsSync()) {
       print('$f not found - aborting');
+      await stdout.flush();
       exit(1);
     }
     final warnF = warn ? (String s) => print(s) : (String _) {};
@@ -108,6 +116,7 @@ class ToSI {
       print('***** Error in ${f.path} *****');
       print('     $e');
       print('');
+      await stdout.flush();
       exit(1);
     }
     final out = File(outFile);

--- a/jovial_svg_transformer/pubspec.lock
+++ b/jovial_svg_transformer/pubspec.lock
@@ -5,23 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: f256b0c0ba6c7577c15e2e4e114755640a875e885099367bf6e012b19314c834
+      sha256: e55636ed79578b9abca5fecf9437947798f5ef7456308b5cb85720b793eac92f
       url: "https://pub.dev"
     source: hosted
-    version: "72.0.0"
-  _macros:
-    dependency: transitive
-    description: dart
-    source: sdk
-    version: "0.3.2"
+    version: "82.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: b652861553cd3990d8ed361f7979dc6d7053a9ac8843fa73820ab68ce5410139
+      sha256: "97536280ed2b09e659b8916be70ec1fb83f2317b653847e2b5efb581add506bf"
       url: "https://pub.dev"
     source: hosted
-    version: "6.7.0"
+    version: "7.4.2"
   args:
     dependency: "direct main"
     description:
@@ -50,18 +45,18 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   convert:
     dependency: transitive
     description:
@@ -195,14 +190,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
-  macros:
-    dependency: transitive
-    description:
-      name: macros
-      sha256: "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.2-main.4"
   matcher:
     dependency: transitive
     description:
@@ -223,10 +210,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
@@ -319,7 +306,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -380,26 +367,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "713a8789d62f3233c46b4a90b174737b2c04cb6ae4500f2aa8b1be8f03f5e67f"
+      sha256: "301b213cd241ca982e9ba50266bd3f5bd1ea33f1455554c5abb85d1be0e2d87e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.8"
+    version: "1.25.15"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.4"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "12391302411737c176b0b5d6491f466b0dd56d4763e347b6714efbaa74d7953d"
+      sha256: "84d17c3486c8dfdbe5e12a50c8ae176d15e2a771b96909a9442b40173649ccaa"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.8"
   typed_data:
     dependency: transitive
     description:
@@ -481,5 +468,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.5.0 <4.0.0"
+  dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.0.0"

--- a/jovial_svg_transformer/test/jovial_svg_transformer_test.dart
+++ b/jovial_svg_transformer/test/jovial_svg_transformer_test.dart
@@ -1,1 +1,16 @@
-void main() {}
+import 'package:jovial_svg_transformer/jovial_svg_transformer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Accepts "input" parameter', () {
+    // Since this calls exit if arguments not valid, the test
+    // will fail all on its own if arguments are not
+    // correct.
+    ToSI().main([
+      "--input",
+      "example/assets/tiger.svg",
+      "--output",
+      "test/temp.si",
+    ]);
+  });
+}


### PR DESCRIPTION
This fixes a couple of issues with jovial_svg_transformer, the most important being that it doesn't actually accept `input` or `output` as parameters. It also adds other missing flags/arguments, fixes a couple of type-safety things and makes sure stdout is flushed before the program exits.

The transformer could _probably_ use a bit of clean-up refactoring beyond this - if I have time one day I'll try to do something but I'm not foreseeing myself having a lot of spare time for a while...

Fixes #129