### PR TITLE
Add canvas save/restore for when clip is applied.

### DIFF
--- a/lib/src/widget.dart
+++ b/lib/src/widget.dart
@@ -266,6 +266,7 @@ abstract class _SyncSIWidgetBase extends ScalableImageWidget {
   void _paintToCanvas(Canvas canvas, Offset offset, Size size) {
     final bounds = offset & size;
     if (_clip) {
+      canvas.save();
       canvas.clipRect(bounds);
     }
     final background = _background;
@@ -298,6 +299,9 @@ abstract class _SyncSIWidgetBase extends ScalableImageWidget {
       if (background != null) {
         canvas.restore();
       }
+    }
+    if (_clip) {
+      canvas.restore();
     }
   }
 }


### PR DESCRIPTION
This fixes an issue when "clip" is used - it clips the entire canvas rather than just the draws that are part of the SVG.  This does it for all canvases which might have a very slight performance effect, although realistically probably close to negligible since save isn't as computationally expensive as savelayer. 